### PR TITLE
Add Filters to PHP SDK

### DIFF
--- a/src/ConnectSDK.php
+++ b/src/ConnectSDK.php
@@ -39,9 +39,9 @@ namespace GettyImages\Connect {
         private $credentials = null;
 
         /** @ignore */
-        private $connectBaseUri = "https://connect.gettyimages.com/v3";
+        private $connectBaseUri = "https://api.gettyimages.com/v3";
 
-        private $authEndpoint = "https://connect.gettyimages.com/oauth2/token";
+        private $authEndpoint = "https://api.gettyimages.com/oauth2/token";
 
         /**
          * Constructor for ConnectSDK

--- a/src/Request/Search/Filters/AgeOfPeople/AgeOfPeopleFilter.php
+++ b/src/Request/Search/Filters/AgeOfPeople/AgeOfPeopleFilter.php
@@ -3,6 +3,7 @@
 namespace GettyImages\Connect\Request\Search\Filters\AgeOfPeople {
 
     abstract class AgeOfPeopleFilter {
+        
         public static function Newborn() {
             return new SpecificAgeFilter("newborn");
         }

--- a/src/Request/Search/Filters/Composition/CompositionFilter.php
+++ b/src/Request/Search/Filters/Composition/CompositionFilter.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace GettyImages\Connect\Request\Search\Filters\Composition {
+
+    abstract class CompositionFilter {
+        public static function Abstract_() {
+            return new AbstractCompositionFilter();
+        }
+
+        public static function Candid() {
+            return new CandidCompositionFilter();
+        }
+        
+        public static function Close_Up() {
+            return new CloseUpCompositionFilter();
+        }
+        
+        public static function Copy_Space() {
+            return new CopySpaceCompositionFilter();
+        }
+        
+        public static function Cut_Out() {            
+            return new CutOutCompositionFilter();
+        }        
+        
+        public static function Full_Frame() {
+            return new FullFrameCompositionFilter();
+        }  
+        
+        public static function Full_Length() {
+            return new FullLengthCompositionFilter();
+        }  
+        
+        public static function Headshot() {
+            return new HeadshotCompositionFilter();
+        }  
+        
+        public static function Looking_At_Camera() {
+            return new LookingAtCameraCompositionFilter();
+        }  
+        
+        public static function Macro() {
+            return new MacroCompositionFilter();
+        }  
+        
+        public static function Portrait() {
+            return new PortriatCompositionFilter();
+        }
+        
+        public static function Sparse() {
+            return new SparseCompositionFilter();
+        }     
+       
+        public static function Still_Life() {
+            return new StillLifeCompositionFilter();
+        }            
+        
+        public static function Three_Quarter_Length() {
+            return new ThreeQuarterLengthCompositionFilter();
+        }     
+        
+        public static function Waist_Up() {
+            return new WaistUpCompositionFilter();
+        }                   
+
+        public abstract function getValue(); 
+    }
+    
+    //////////////////////////////////////////////////////////////
+    
+    class AbstractCompositionFilter extends CompositionFilter {
+        public function getValue() {
+            return "abstract";            
+        }
+    }
+    
+    class CandidCompositionFilter extends CompositionFilter {
+        public function getValue() {
+            return "candid";            
+        }
+    }
+    
+    class CloseUpCompositionFilter extends CompositionFilter {
+        public function getValue() {
+            return "close_up";            
+        }
+    }
+    
+    class CopySpaceCompositionFilter extends CompositionFilter {
+        public function getValue() {
+            return "copy_space";
+        }
+    }
+    
+    class CutOutCompositionFilter extends CompositionFilter {
+        public function getValue() {
+            return "cut_out";            
+        }
+    }              
+    
+    class FullFrameCompositionFilter extends CompositionFilter {
+        public function getValue() {
+            return "full_frame";            
+        }
+    }  
+    
+    class FullLengthCompositionFilter extends CompositionFilter {
+        public function getValue() {
+            return "full_length";
+        }
+    }
+    
+    class HeadshotCompositionFilter extends CompositionFilter {
+        public function getValue() {
+            return "headshot";
+        }
+    }
+    
+    class LookingAtCameraCompositionFilter extends CompositionFilter {
+        public function getValue() {
+            return "looking_at_camera";            
+        }
+    }  
+    
+    class MacroCompositionFilter extends CompositionFilter {
+        public function getValue() {
+            return "macro";            
+        }
+    }  
+    
+    class PortriatCompositionFilter extends CompositionFilter {
+        public function getValue() {
+            return "portrait";
+        }
+    }
+    
+    class SparseCompositionFilter extends CompositionFilter {
+        public function getValue() {
+            return "sparse";            
+        }
+    }      
+    
+    class StillLifeCompositionFilter extends CompositionFilter {
+        public function getValue() {
+            return "still_life";            
+        }
+    }  
+    
+    class ThreeQuarterLengthCompositionFilter extends CompositionFilter {
+        public function getValue() {
+            return "three_quarter_length";            
+        }
+    }  
+    
+    class WaistUpCompositionFilter extends CompositionFilter {
+        public function getValue() {
+            return "waist_up";            
+        }
+    }      
+}

--- a/src/Request/Search/Filters/Ethnicity/EthnicityFilter.php
+++ b/src/Request/Search/Filters/Ethnicity/EthnicityFilter.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace GettyImages\Connect\Request\Search\Filters\Ethnicity {
+
+    abstract class EthnicityFilter {
+        public static function Black() {
+            return new BlackEthnicityFilter();
+        }
+
+        public static function Caucasian() {
+            return new CaucasianEthnicityFilter();
+        }
+        
+        public static function East_Asian() {
+            return new EastAsianEthnicityFilter();
+        }
+        
+        public static function Hispanic_Latino() {
+            return new HispanicLatinoEthnicityFilter();
+        }  
+        
+        public static function Japanese() {
+            return new JapaneseEthnicityFilter();
+        }
+        
+        public static function Middle_Eastern() {
+            return new MiddleEasternEthnicityFilter();
+        }  
+        
+        public static function Mixed_Race_Person() {
+            return new MixedRacePersonEthnicityFilter();
+        }
+        
+        public static function Multiethnic_Group() {
+            return new MultiethnicGroupEthnicityFilter();
+        }
+        
+        public static function Native_American_First_Nations() {
+            return new NativeAmericanFirstNationsEthnicityFilter();
+        }
+        
+        public static function Pacific_Islander() {
+            return new PacificIslanderEthnicityFilter();
+        }  
+        
+        public static function South_Asian() {
+            return new SouthAsianEthnicityFilter();
+        }
+        
+        public static function Southeast_Asian() {
+            return new SoutheastAsianEthnicityFilter();
+        }                  
+        
+        public abstract function getValue(); 
+    }
+    
+    
+    
+    class BlackEthnicityFilter extends EthnicityFilter {
+        public function getValue() {
+            return "black";            
+        }
+    }    
+    
+    class CaucasianEthnicityFilter extends EthnicityFilter {
+        public function getValue() {
+            return "caucasian";            
+        }
+    }    
+
+    class EastAsianEthnicityFilter extends EthnicityFilter {
+        public function getValue() {
+            return "east_asian";            
+        }
+    }
+    
+    class HispanicLatinoEthnicityFilter extends EthnicityFilter {
+        public function getValue() {
+            return "hispanic_latino";            
+        }
+    }
+    
+    class JapaneseEthnicityFilter extends EthnicityFilter {
+        public function getValue() {
+            return "japanese";            
+        }
+    }
+    
+    class MiddleEasternEthnicityFilter extends EthnicityFilter {
+        public function getValue() {
+            return "middle_eastern";            
+        }
+    } 
+    
+    class MixedRacePersonEthnicityFilter extends EthnicityFilter {
+        public function getValue() {
+            return "mixed_race_person";            
+        }
+    }
+    
+    class MultiethnicGroupEthnicityFilter extends EthnicityFilter {
+        public function getValue() {
+            return "multiethnic_group";            
+        }
+    }    
+    
+    class NativeAmericanFirstNationsEthnicityFilter extends EthnicityFilter {
+        public function getValue() {
+            return "native_american_first_nations";            
+        }
+    } 
+    
+    class PacificIslanderEthnicityFilter extends EthnicityFilter {
+        public function getValue() {
+            return "pacific_islander";            
+        }
+    } 
+    
+    class SouthAsianEthnicityFilter extends EthnicityFilter {
+        public function getValue() {
+            return "south_asian";            
+        }
+    } 
+    
+    class SoutheastAsianEthnicityFilter extends EthnicityFilter {
+        public function getValue() {
+            return "southeast_asian";            
+        }
+    }      
+}

--- a/src/Request/Search/Filters/FileType/FileTypeFilter.php
+++ b/src/Request/Search/Filters/FileType/FileTypeFilter.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace GettyImages\Connect\Request\Search\Filters\FileType {
+
+    abstract class FileTypeFilter {
+
+        public static function Eps() {
+            return new EpsFileTypeFilter();
+        }
+        
+        public static function Gif() {
+            return new GifFileTypeFilter();
+        }
+        
+        public static function Jpg() {
+            return new JpgFileTypeFilter();
+        }        
+
+        public static function Png() {
+            return new PngFileTypeFilter();
+        }        
+        
+        public abstract function getValue(); 
+    }
+    
+    
+    class EpsFileTypeFilter extends FileTypeFilter {
+        public function getValue() {
+            return "eps";            
+        }
+    }
+    
+    class GifFileTypeFilter extends FileTypeFilter {
+        public function getValue() {
+            return "gif";            
+        }
+    }
+    
+    class JpgFileTypeFilter extends FileTypeFilter {
+        public function getValue() {
+            return "jpg";            
+        }
+    }
+    
+    class PngFileTypeFilter extends FileTypeFilter {
+        public function getValue() {
+            return "png";            
+        }
+    }    
+}

--- a/src/Request/Search/Filters/GraphicalStyle/IllustrationGraphicalStyle.php
+++ b/src/Request/Search/Filters/GraphicalStyle/IllustrationGraphicalStyle.php
@@ -9,7 +9,7 @@
 namespace GettyImages\Connect\Request\Search\Filters\GraphicalStyle;
 
 class IllustrationGraphicalStyleFilter extends GraphicalStyleFilter {
-    function getValue()
+    public function getValue()
     {
         return "illustration";
     }

--- a/src/Request/Search/Filters/LicenseModel/LicenseModelFilter.php
+++ b/src/Request/Search/Filters/LicenseModel/LicenseModelFilter.php
@@ -1,22 +1,15 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: Owner
- * Date: 9/17/14
- * Time: 10:50 AM
- */
 
 namespace GettyImages\Connect\Request\Search\Filters\LicenseModel {
-
     require_once("RightsManagedLicenseModel.php");
     require_once("RoyaltyFreeLicenseModel.php");
 
     abstract class LicenseModelFilter {
-        public static function Rights_Managed() {
+        public static function RightsManaged() {
             return new RightsManagedLicenseModelFilter();
         }
 
-        public static function Royalty_Free() {
+        public static function RoyaltyFree() {
             return new RoyaltyFreeLicenseModelFilter();
         }
 

--- a/src/Request/Search/Filters/LicenseModel/RightsManagedLicenseModel.php
+++ b/src/Request/Search/Filters/LicenseModel/RightsManagedLicenseModel.php
@@ -1,15 +1,10 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: Owner
- * Date: 9/17/14
- * Time: 11:27 AM
- */
 
-namespace GettyImages\Connect\Request\Search\Filters\LicenseModel;
-
-class RightsManagedLicenseModelFilter extends LicenseModelFilter {
-    function getValue() {
-        return "rights_managed";
+namespace GettyImages\Connect\Request\Search\Filters\LicenseModel {
+    class RightsManagedLicenseModelFilter extends LicenseModelFilter {
+        function getValue() {
+            return "rightsmanaged";
+        }
     }
 }
+

--- a/src/Request/Search/Filters/LicenseModel/RoyaltyFreeLicenseModel.php
+++ b/src/Request/Search/Filters/LicenseModel/RoyaltyFreeLicenseModel.php
@@ -1,15 +1,10 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: Owner
- * Date: 9/17/14
- * Time: 11:26 AM
- */
 
-namespace GettyImages\Connect\Request\Search\Filters\LicenseModel;
-
-class RoyaltyFreeLicenseModelFilter extends LicenseModelFilter {
-    public function getValue() {
-        return "royalty_free";
-    }
+namespace GettyImages\Connect\Request\Search\Filters\LicenseModel {
+    class RoyaltyFreeLicenseModelFilter extends LicenseModelFilter {
+        public function getValue() {
+            return "royaltyfree";
+        }
+    }    
 }
+

--- a/src/Request/Search/Search.php
+++ b/src/Request/Search/Search.php
@@ -2,10 +2,15 @@
 
 namespace GettyImages\Connect\Request\Search {
     //Require Filters
+    require_once("Filters/Ethnicity/EthnicityFilter.php");
     require_once("Filters/EditorialSegment/EditorialSegmentFilter.php");
     require_once("Filters/GraphicalStyle/GraphicalStyleFilter.php");
     require_once("Filters/LicenseModel/LicenseModelFilter.php");
     require_once("Filters/Orientation/OrientationFilter.php");
+    require_once("Filters/NumberOfPeople/NumberOfPeopleFilter.php");
+    require_once("Filters/AgeOfPeople/AgeOfPeopleFilter.php");
+    require_once("Filters/FileType/FileTypeFilter.php");
+    require_once("Filters/Composition/CompositionFilter.php");
 
     //Require Other Search Types
     require_once("SearchImages.php");

--- a/src/Request/Search/SearchImages.php
+++ b/src/Request/Search/SearchImages.php
@@ -10,6 +10,9 @@ namespace GettyImages\Connect\Request\Search {
     use GettyImages\Connect\Request\Search\Filters\Orientation\OrientationFilter;
     use GettyImages\Connect\Request\Search\Filters\NumberOfPeople\NumberOfPeopleFilter;
     use GettyImages\Connect\Request\Search\Filters\AgeOfPeople\AgeOfPeopleFilter;        
+    use GettyImages\Connect\Request\Search\Filters\Ethnicity\EthnicityFilter;
+    use GettyImages\Connect\Request\Search\Filters\FileType\FileTypeFilter;
+    use GettyImages\Connect\Request\Search\Filters\Composition\CompositionFilter;
 
     /**
      * Provides Image Search specific behavior
@@ -76,8 +79,8 @@ namespace GettyImages\Connect\Request\Search {
         public function withPageSize($pageSize) {
             $this->requestDetails["page_size"] = $pageSize;
             return $this;
-        }      
-        
+        }
+
         /**
          * Adds the specific request field to the results
          */
@@ -86,18 +89,22 @@ namespace GettyImages\Connect\Request\Search {
             return $this;
         }
 
-        public function withProductType($type) {
-            $this->appendArrayValueToRequestDetails("product_types", $type);
+        /**
+         * @param ProductTypeFilter $productType
+         * @throws Exception
+         * @return $this
+         */
+        public function withProductType($productType) {
+            $this->appendArrayValueToRequestDetails("product_types", $productType);
             return $this;
         }
 
         /**
          * @param OrientationFilter $orientation
-         * @internal param \Orientation|\use $orientationName use values from Orientation::
+         * @throws Exception
          * @return $this
          */
         public function withOrientation(OrientationFilter $orientation) {
-
             $this->appendArrayValueToRequestDetails("orientations",$orientation->getValue());
             return $this;
         }
@@ -108,7 +115,6 @@ namespace GettyImages\Connect\Request\Search {
          * @return $this
          */
         public function withLicenseModel(LicenseModelFilter $licenseModel) {
-
             $this->appendArrayValueToRequestDetails("license_models",$licenseModel->getValue());
             return $this;
         }
@@ -133,12 +139,113 @@ namespace GettyImages\Connect\Request\Search {
         }
 
         /**
+         * @param $ethnicity
+         * @throws Exception
+         * @return $this
+         */
+        public function withEthnicity(EthnicityFilter $ethnicity) {
+            $this->appendArrayValueToRequestDetails("ethnicity",$ethnicity->getValue());
+            return $this;
+        }
+
+        /**
          * @param $locations
          * @return $this
          */
         public function withSpecificLocations($locations) {
             $this->requestDetails["specific_locations"] = $locations;
-
+            return $this;
+        }
+        
+        /**
+         * @param $people
+         * @return $this
+         */
+        public function withSpecificPeople($people) {
+            $this->requestDetails["specific_people"] = $people;
+            return $this;
+        }        
+        
+        /**
+         * @param $artists
+         * @return $this
+         */
+        public function withArtists($artists) {
+            $this->requestDetails["artists"] = $artists;
+            return $this;
+        }        
+        
+        /**
+         * @param $composition
+         * @return $this
+         */
+        public function withComposition(CompositionFilter $compositions) {
+            $this->appendArrayValueToRequestDetails("compositions",$compositions->getValue());
+            return $this;
+        }
+        
+        /**
+         * @param $fileType
+         * @throws Exception
+         * @return $this
+         */
+        public function withFileType(FileTypeFilter $fileType) {
+            $this->appendArrayValueToRequestDetails("file_types",$fileType->getValue());
+            return $this;
+        }
+        
+        /**
+         * @param $collectionCode
+         * @return $this
+         */
+        public function withCollectionCode($collectionCode) {
+            $this->requestDetails["collection_codes"] = $collectionCode;
+            $this->requestDetails["collections_filter_type"] = "include";
+            return $this;
+        }
+        
+        /**
+         * @param $collectionCode
+         * @return $this
+         */
+        public function withoutCollectionCode($collectionCode) {
+            $this->requestDetails["collection_codes"] = $collectionCode;
+            $this->requestDetails["collections_filter_type"] = "exclude";
+            return $this;
+        }
+        
+        /**
+         * @param $keywordId
+         * @throws Exception
+         * @return $this
+         */
+        public function withKeywordId($keywordId) {
+            if (!is_int($keywordId) || $keywordId<0) {
+                throw new InvalidArgumentException('withKeywordId function only accepts positive integers. Input was: '.$keywordId); 
+            }
+            $this->requestDetails["keyword_ids"] = $keywordId;
+            return $this;
+        }        
+        
+        /**
+         * Scopes response down to only prestige curated content
+         */
+        public function withOnlyPrestigeContent()
+        {
+            $this->requestDetails["prestige_content_only"] = "true";
+            return $this;
+        }
+        
+       /**
+         * @param $eventId
+         * @throws Exception
+         * @return $this
+         */
+        public function withEventId($eventId) {
+            if (!is_int($eventId) || $eventId<0) {
+                throw new InvalidArgumentException('withEventId function only accepts positive integers. Input was: '.$eventId); 
+            }
+            $this->requestDetails["event_ids"] = $eventId;
             return $this;
         }
         
@@ -158,7 +265,7 @@ namespace GettyImages\Connect\Request\Search {
         public function withAgeOfPeople(AgeOfPeopleFilter $age) {
             $this->appendArrayValueToRequestDetails("age_of_people",$age->getValue());
             return $this;
-        }
+        }             
         
         /**
          * @param $order


### PR DESCRIPTION
I recommend we flatten the filter class files fully when we add Video Search Filters for consistency and readability and given those classes are just being used to emulate strong types, namely enums, which php lacks.  I started doing this with some of the new filters.  Otherwise, I ended up following the established pattern.  