### PR TITLE
Fixed composer package name

### DIFF
--- a/README_ComposerInstall.md
+++ b/README_ComposerInstall.md
@@ -11,7 +11,7 @@ Create composer.json with these contents
 
     {
       "require": {
-	       "gettyimages/apiclient": "dev-master"
+	       "gettyimages/gettyimages-api": "dev-master"
       }
     }
 
@@ -36,4 +36,4 @@ Create your .php file
 
 ### Already established Project
 
-    composer require gettyimages/apiclient
+    composer require gettyimages/gettyimages-api


### PR DESCRIPTION
After trying to install the documented package, I encountered the error:

```
The requested package gettyimages/apiclient could not be found in any version, there may be a typo in the package name.
```

A [search on Packagist](https://packagist.org/packages/gettyimages/gettyimages-api) revealed the correct package name.