### PR TITLE
Remove license_model as a Parameter

### DIFF
--- a/src/Request/Search/SearchImages.php
+++ b/src/Request/Search/SearchImages.php
@@ -158,16 +158,6 @@ namespace GettyImages\Api\Request\Search {
             return $this;
         } 
 
-        /**
-         * @param array $licenseModels An array of license models by which to filter.
-         * @throws Exception
-         * @return $this
-         */
-        public function withLicenseModels(array $licenseModels) {
-            $this->addArrayOfValuesToRequestDetails("license_models",$licenseModels);
-            return $this;
-        }
-
            /**
          * @param string $minimumSize
          * @return $this

--- a/src/Request/Search/SearchImagesCreative.php
+++ b/src/Request/Search/SearchImagesCreative.php
@@ -154,16 +154,6 @@ namespace GettyImages\Api\Request\Search {
             return $this;
         } 
 
-        /**
-         * @param array $licenseModels An array of license models by which to filter.
-         * @throws Exception
-         * @return $this
-         */
-        public function withLicenseModels(array $licenseModels) {
-            $this->addArrayOfValuesToRequestDetails("license_models",$licenseModels);
-            return $this;
-        }
-
            /**
          * @param string $minimumSize
          * @return $this

--- a/unitTests/Search/SearchImagesCreativeTest.php
+++ b/unitTests/Search/SearchImagesCreativeTest.php
@@ -247,24 +247,6 @@ final class SearchImagesCreativeTest extends TestCase
         $this->assertContains("keyword_ids=64284%2C67255", $curlerMock->options[CURLOPT_URL]);
     }
 
-    public function testSearchImagesCreativeWithLicenseModels()
-    {
-        $curlerMock = new CurlerMock();
-        $builder = new \DI\ContainerBuilder();
-        $container = $builder->build();
-        $container->set('ICurler', $curlerMock);
-
-        $models = array("rightsmanaged", "royaltyfree");
-
-        $client = GettyImages_Client::getClientWithClientCredentials("", "", $container);
-
-        $search = $client->SearchImagesCreative()->withPhrase("cat")->withLicenseModels($models)->execute();
-
-        $this->assertContains("search/images/creative", $curlerMock->options[CURLOPT_URL]);
-        $this->assertContains("phrase=cat", $curlerMock->options[CURLOPT_URL]);
-        $this->assertContains("license_models=rightsmanaged%2Croyaltyfree", $curlerMock->options[CURLOPT_URL]);
-    }
-
     public function testSearchImagesCreativeWithMinimumSize()
     {
         $curlerMock = new CurlerMock();

--- a/unitTests/Search/SearchImagesTest.php
+++ b/unitTests/Search/SearchImagesTest.php
@@ -305,24 +305,6 @@ final class SearchImagesTest extends TestCase
         $this->assertContains("keyword_ids=64284%2C67255", $curlerMock->options[CURLOPT_URL]);
     }
 
-    public function testSearchImagesWithLicenseModels()
-    {
-        $curlerMock = new CurlerMock();
-        $builder = new \DI\ContainerBuilder();
-        $container = $builder->build();
-        $container->set('ICurler', $curlerMock);
-
-        $models = array("rightsmanaged", "royaltyfree");
-
-        $client = GettyImages_Client::getClientWithClientCredentials("", "", $container);
-
-        $search = $client->SearchImages()->withPhrase("cat")->withLicenseModels($models)->execute();
-
-        $this->assertContains("search/images", $curlerMock->options[CURLOPT_URL]);
-        $this->assertContains("phrase=cat", $curlerMock->options[CURLOPT_URL]);
-        $this->assertContains("license_models=rightsmanaged%2Croyaltyfree", $curlerMock->options[CURLOPT_URL]);
-    }
-
     public function testSearchImagesWithMinimumSize()
     {
         $curlerMock = new CurlerMock();


### PR DESCRIPTION
Remove license_model from SearchImages and SearchImagesCreative.
Update Tests to reflect change.