### PR TITLE
fix order of params because optional parameter should be last

### DIFF
--- a/src/Request/FluentRequest.php
+++ b/src/Request/FluentRequest.php
@@ -125,7 +125,7 @@ namespace GettyImages\Api\Request {
                 default:
                     throw new \Exception("No appropriate HTTP method found for this request.");
             }
-            
+
             return $this->handleResponse($response);
         }
 
@@ -134,16 +134,17 @@ namespace GettyImages\Api\Request {
          */
         protected function executeFileUpload(string $route, string $filepath) {
             $endpointUrl = $this->endpointUri."/".$route;
-            
+
             $this->options[CURLOPT_HTTPHEADER][] = "Api-Key:".$this->credentials->getApiKey();
 
             $webHelper = new WebHelper($this->container);
 
             $response = $webHelper->putImageRequest($endpointUrl,
-                                    $this->requestDetails,
-                                    $this->options,
-                                    $filepath);
-            
+                $this->requestDetails,
+                $filepath,
+                $this->options
+            );
+
             return $this->handleResponse($response);
         }
 

--- a/src/Request/FluentRequest.php
+++ b/src/Request/FluentRequest.php
@@ -140,10 +140,9 @@ namespace GettyImages\Api\Request {
             $webHelper = new WebHelper($this->container);
 
             $response = $webHelper->putImageRequest($endpointUrl,
-                $this->requestDetails,
-                $filepath,
-                $this->options
-            );
+                                    $this->requestDetails,
+                                    $filepath,
+                                    $this->options);
 
             return $this->handleResponse($response);
         }

--- a/src/Request/WebHelper.php
+++ b/src/Request/WebHelper.php
@@ -97,11 +97,11 @@ namespace GettyImages\Api\Request {
          * Send a PUT requst using cURL
          * @param string $url to request
          * @param array $queryParams values to send
-         * @param array $options for cURL
          * @param string $filepath of image to add
+         * @param array $options for cURL
          * @return string
          */
-        public function putImageRequest($endpoint, $queryParams, array $options = array(), string $filepath) {
+        public function putImageRequest($endpoint, $queryParams, string $filepath, array $options = array()) {
 
             $image = fopen($filepath, "rb");
 


### PR DESCRIPTION
The PR fixes this deprecation warning:

```
PHP Deprecated:  Optional parameter $options declared before required parameter $filepath is implicitly treated 
as a required parameter in /myposter/vendor/gettyimages/gettyimages-api/src/Request/WebHelper.php on line 104
```