### PR TITLE
Remove unused Curler::$options property

### DIFF
--- a/src/Curler/Curler.php
+++ b/src/Curler/Curler.php
@@ -6,8 +6,6 @@ namespace GettyImages\Api\Curler {
     {
         public function execute($options)
         {
-            $this->options = $options;
-
             $ch = curl_init();
             curl_setopt_array($ch, $options);
             $response = curl_exec($ch);


### PR DESCRIPTION
Fixes #30.

It appears to be a copy-paste leftover from `CurlerMock` where `$options` was actually defined:

https://github.com/gettyimages/gettyimages-api_php/blob/662a72bbe4d3b9f94c0f8c97be59beb25d0a5309/src/Curler/CurlerMock.php#L7

and can be safely removed.