### PR TITLE
Update PHP version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4' ]
+        php: [ '8.3', '8.4', '8.5' ]
     steps:
       - uses: actions/checkout@v2
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "source": "https://github.com/gettyimages/gettyimages-api_php"
     },
     "require": {
-        "php": ">=7.0",
+        "php": ">=8.3",
         "php-di/php-di": "^6.0"
     },
     "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev" : {
         "phine/phar": "~1.0",
-        "phpunit/phpunit": "^6"
+        "phpunit/phpunit": "^10.0"
     },
     "autoload" : {
         "psr-4" : {


### PR DESCRIPTION
- Update build to use 8.x versions
- Update required version in package file to >=8.3

This is to deprecate support for unsupported version of PHP.